### PR TITLE
Add GreenPill podcast; update community headings and Civic Tech description

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@
           <li><a href="https://pods.media/is-this-the-new-internet" target="_blank"><strong>The New Internet</strong> - A podcast for people who deeply care about the internet, and want it to be better.</a></li>
           <li><a href="https://www.youtube.com/@AziziPodcast" target="_blank"><strong>Azizi Podcast</strong> - Run by Samir of Toronto DAO fame.</a></li>
           <li><a href="https://www.youtube.com/@TheKusamarian" target="_blank"><strong>The Kus</strong> - The Kusamarian is based in Tororonto and rus a great weekly show "Attempts At Governance"</a></li>
+          <li><a href="https://www.youtube.com/@Green_Pill_Podcast" target="_blank"><strong>GreenPill</strong> - The original podcast from which the Greenpill Network grew. Find it wherever you get your podcasts, or on YouTube.</a></li>
           <!-- Add more organizations and projects as needed -->
         </ul>
       </div>
@@ -120,10 +121,9 @@
     <!-- Community Meetups Section -->
     <section id="community-section" class="affiliates">
       <div class="wrapper">
-        <h1 class="title">Other Web3 Communities & Organizations in Toronto</h1>
+        <h1 class="title">Other Web3 Communities & Tech Organizations in Toronto</h1>
         <ul class="affiliates-list">
           <li><a href="https://lu.ma/GreenPillTO" target="_blank"><strong>GreenPill TO</strong> - Our own weekly online hangout</a></li>
-          <li><a href="https://lu.ma/calendar/cal-oZi0aFQ0NKtV1SM" target="_blank"><strong>Beaches Crypto Commies</strong> - Occasionally meeting up at Castro's Lounge in Toronto's east end.</a></li>
           <li><a href="https://members.tdao.to/" target="_blank"><strong>Toronto DAO</strong> - TDAO is most active on Telegram</a></li>
           <li><a href="https://www.web3to.ca/" target="_blank"><strong>Web3TO</strong> - Most active on their WhatsApp</a></li>
           <li><a href="https://www.mainchain.to/" target="_blank"><strong>MainChain</strong> - Good listing of local projects</a></li>
@@ -140,11 +140,11 @@
       <div class="wrapper">
         <h1 class="title">Not web3 but...</h1>
         <ul class="affiliates-list">
-          <li><strong><a href="https://civictech.ca/" target="_blank">Civic Tech Toronto</a></strong> - Weekly civic tech meetup with events listed on <a href="https://guild.host/civic-tech-toronto/events" target="_blank">Guild</a>.</li>
-          <li><strong><a href="https://weavetoronto.notion.site/" target="_blank">Weave Toronto Community</a></strong> - A community aspiring to learn, conduct research, and do great work together. Join the conversation on <a href="https://chat.whatsapp.com/FO5HOrbdXnhHGTUfJg0tdv" target="_blank">WhatsApp</a>.</li>
-          <li><strong><a href="https://www.tocw.ca/" target="_blank">Toronto Climate Week</a></strong> - Inaugural events Oct 1–3, 2025 with a week-long gathering launching June 2026. Learn more on <a href="https://luma.com/tocw" target="_blank">Luma</a>.</li>
-          <li><strong><a href="https://www.torontotechweek.com" target="_blank">Toronto Tech Week</a></strong> - Returning May 25–29, 2026.</li>
-          <li><strong><a href="https://www.elevatefestival.ca" target="_blank">Elevate Festival</a></strong> - Celebrating tech and innovation October 7–9, 2025.</li>
+          <li><a href="https://civictech.ca/" target="_blank"><strong>Civic Tech Toronto</strong></a> - Meet every Tuesday to work on projects, hear from thoughtful speakers, and connect with others who care about how technology can improve our communities. Events listed on <a href="https://guild.host/civic-tech-toronto/events" target="_blank">Guild</a>.</li>
+          <li><a href="https://weavetoronto.notion.site/" target="_blank"><strong>Weave Toronto Community</strong></a> - A community aspiring to learn, conduct research, and do great work together. Join the conversation on <a href="https://chat.whatsapp.com/FO5HOrbdXnhHGTUfJg0tdv" target="_blank">WhatsApp</a>.</li>
+          <li><a href="https://www.tocw.ca/" target="_blank"><strong>Toronto Climate Week</strong></a> - Inaugural events Oct 1–3, 2025 with a week-long gathering launching June 2026. Learn more on <a href="https://luma.com/tocw" target="_blank">Luma</a>.</li>
+          <li><a href="https://www.torontotechweek.com" target="_blank"><strong>Toronto Tech Week</strong></a> - Returning May 25–29, 2026.</li>
+          <li><a href="https://www.elevatefestival.ca" target="_blank"><strong>Elevate Festival</strong></a> - Celebrating tech and innovation October 7–9, 2025.</li>
         </ul>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Add GreenPill as a fourth podcast entry to acknowledge the original show that spawned the Greenpill Network and link to its YouTube channel. 
- Broaden the community header to include tech organizations and remove an outdated meetup entry (Beaches Crypto Commies). 
- Make the "Not web3 but..." section visually consistent with the other affiliates sections and update Civic Tech wording and links to provide clearer event info.

### Description
- Updated `index.html` to add a new podcast list item linking to `https://www.youtube.com/@Green_Pill_Podcast` with label `GreenPill`. 
- Renamed the community section header from `Other Web3 Communities & Organizations in Toronto` to `Other Web3 Communities & Tech Organizations in Toronto`. 
- Removed the `Beaches Crypto Commies` list item from the community list. 
- Reformatted the "Not web3 but..." section markup to match other affiliate entries and replaced the Civic Tech Toronto list item text with the requested description and Guild link (`https://guild.host/civic-tech-toronto/events`).

### Testing
- Started a local server with `python -m http.server` and used a Playwright script to load `http://127.0.0.1:8000/index.html` and capture `artifacts/podcast-community-updates.png`, which completed successfully. 
- Verified the modified `index.html` is staged and committed; commit completed successfully. 
- No unit tests were added for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979281de3a083249a7082ac3d6ca56c)